### PR TITLE
Upgrade to go1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-cluster-management/managedcluster-import-controller
 
-go 1.15
+go 1.16
 
 require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/11916

Signed-off-by: Dominique Vernier <dvernier@redhat.com>